### PR TITLE
Fix missing Podfile info

### DIFF
--- a/RNGameCenter/ios/RNGameCenter.podspec
+++ b/RNGameCenter/ios/RNGameCenter.podspec
@@ -6,12 +6,12 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNGameCenter
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/garrettmac/RNGameCenter"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNGameCenter.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/garrettmac/RNGameCenter.git", :tag => "master" }
   s.source_files  = "RNGameCenter/**/*.{h,m}"
   s.requires_arc = true
 


### PR DESCRIPTION
Without this, I am seeing:

```
[!] The `RNGameCenter` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```